### PR TITLE
Typo fix: Leis*t*ungshebel

### DIFF
--- a/source/d-erfh_procedure_de_a4.tex
+++ b/source/d-erfh_procedure_de_a4.tex
@@ -32,7 +32,7 @@
       \hint{Nach max. 5 Sekunden}
     \item{Kraftstoffpumpe}{aus}
     \decision{Kaltstart}
-      \step{Leisungshebel: Leerlauf}
+      \step{Leistungshebel: Leerlauf}
       \step{Choke: Ziehen}
     \decision{Warmstart}
       \step{Leistungshebel: 1cm}

--- a/source/d-erfh_procedure_de_a6.tex
+++ b/source/d-erfh_procedure_de_a6.tex
@@ -39,7 +39,7 @@
       \hint{Nach max. 5 Sekunden}
     \item{Kraftstoffpumpe}{aus}
     \decision{Kaltstart}
-      \step{Leisungshebel: Leerlauf}
+      \step{Leistungshebel: Leerlauf}
       \step{Choke: Ziehen}
     \decision{Warmstart}
       \step{Leistungshebel: 1cm}


### PR DESCRIPTION
This fixes the wrongly spelled "Leisungshebel" to "Leistungshebel".

I do not know whether this change should trigger an update to the arguments to the `\versionchecklist` and `\datechecklist` commands.