### PR TITLE
README.md: Document that ttfutils is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 
 This is a simple set of LaTex files to produce nice PDF formatted checklists.
-You need to have a LaTex environment set up and `xelatex` available.
+
+You need to have a LaTex environment set up with `xelatex` and `ttfutils` available.
 
 ## Creating a checklist
 


### PR DESCRIPTION
This documents that the `ttfutils` package is required to produce PDF files.

Unlike the `texlive-cuprum` package being required for the "cuprum" latex fonts and package, the `texlive-ttfutls` package being required is far less obvious.

  * Using xelatex:

        xdvipdfmx:fatal: Cannot proceed without .vf or "physical" font for PDF output...

        No output PDF file written.

  * Using pdflatex:

        !pdfTeX error: pdflatex (file T1-WGL4.enc): cannot open encoding file for reading
         ==> Fatal error occurred, no output PDF file produced!

One `dnf install texlive-ttfutls` later, both `pdflatex` and `xelatex` successfully produce PDF files.