### PR TITLE
make: In case of any command failing, immediately abort the for loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,14 @@ prepare_directories:
 	mkdir -p $(OUTPUT_DIR)
 
 compile: $(SOURCES)
-	@for i in $(SOURCES); do \
-        echo Building $$i from source && \
-		xelatex -output-dir=$(BUILD_DIR) $$i; \
-		xelatex -output-dir=$(BUILD_DIR) $$i; \
-		xelatex -output-dir=$(BUILD_DIR) $$i; \
-    done
-	
+	@set -ex; \
+	for i in $(SOURCES); do \
+		echo "Building $$i from source"; \
+		xelatex -output-dir=$(BUILD_DIR) "$$i"; \
+		xelatex -output-dir=$(BUILD_DIR) "$$i"; \
+		xelatex -output-dir=$(BUILD_DIR) "$$i"; \
+	done
+
 publish:
 	mv $(BUILD_DIR)/*.pdf $(OUTPUT_DIR)
 
@@ -27,6 +28,7 @@ cleanup:
 	rm -rf $(BUILD_DIR)
 
 list_sources:
-	@for i in $(SOURCES); do \
-        echo $$i; \
-    done
+	@set -ex; \
+	for i in $(SOURCES); do \
+		echo "$$i"; \
+	done


### PR DESCRIPTION
In the case of any command inside a `for` loop failing, the `for` loop and the make recipe containing it should fail immediately as well.

Otherwise if e.g. every `xelatex` call fails, running `make` will unnecessarily call `xelatex` on every `source/*.tex` file three three times for no additional benefit over just calling `xelatex` once.

Or if e.g. only the last tex file builds successfully and all other tex file builds fail, `make` will mistakenly finish successfully.