### PR TITLE
move documentclass definition from preamble to document

### DIFF
--- a/preamble.inc
+++ b/preamble.inc
@@ -5,7 +5,6 @@
 % Allowed values for "papersize": [4,5,6]
 % ---------------------------------------------------------------
 \if\papersize4
-  \documentclass[12pt]{article}
   \usepackage[a4paper, twocolumn]{geometry}
   \geometry{
     total={192mm,280mm},
@@ -19,7 +18,6 @@
   }
 \fi
 \if\papersize5
-  \documentclass[10pt]{article}
   \usepackage[a5paper, twocolumn]{geometry}
   \geometry{
     total={130mm,190mm},
@@ -33,7 +31,6 @@
   }
 \fi
 \if\papersize6
-  \documentclass[10pt]{article}
   \usepackage[a6paper, twocolumn]{geometry}
   \geometry{
     total={95.5mm,130mm},
@@ -47,7 +44,6 @@
     }
 \fi
 \if\papersize7
-  \documentclass[10pt]{article}
   \usepackage[a6paper]{geometry}
   \geometry{
     total={80.5mm,130mm},

--- a/source/d-edfy_checks_a6.tex
+++ b/source/d-edfy_checks_a6.tex
@@ -1,3 +1,4 @@
+\documentclass[10pt]{article}
 \def\papersize{6}
 \input{preamble.inc}
 

--- a/source/d-edfy_procedure_a4.tex
+++ b/source/d-edfy_procedure_a4.tex
@@ -1,3 +1,4 @@
+\documentclass[12pt]{article}
 \def\papersize{4}
 \input{preamble.inc}
 

--- a/source/d-edgx_checks_en_a4.tex
+++ b/source/d-edgx_checks_en_a4.tex
@@ -1,3 +1,4 @@
+\documentclass[12pt]{article}
 \def\papersize{4}
 \input{preamble.inc}
 

--- a/source/d-edgx_procedure_en_a4.tex
+++ b/source/d-edgx_procedure_en_a4.tex
@@ -1,3 +1,4 @@
+\documentclass[12pt]{article}
 \def\papersize{4}
 \input{preamble.inc}
 

--- a/source/d-erfh_procedure_de_a4.tex
+++ b/source/d-erfh_procedure_de_a4.tex
@@ -1,3 +1,4 @@
+\documentclass[12pt]{article}
 \def\papersize{4}
 \input{preamble.inc}
 

--- a/source/d-erfh_procedure_de_a6.tex
+++ b/source/d-erfh_procedure_de_a6.tex
@@ -1,3 +1,4 @@
+\documentclass[10pt]{article}
 \def\papersize{7}
 \input{preamble.inc}
 

--- a/source/example.tex
+++ b/source/example.tex
@@ -1,3 +1,4 @@
+\documentclass[12pt]{article}
 \def\papersize{4}
 \input{preamble.inc}
 

--- a/source/misc_edgx.tex
+++ b/source/misc_edgx.tex
@@ -1,3 +1,4 @@
+\documentclass[10pt]{article}
 \def\papersize{6}
 \input{preamble.inc}
 

--- a/source/misc_units.tex
+++ b/source/misc_units.tex
@@ -1,3 +1,4 @@
+\documentclass[10pt]{article}
 \def\papersize{6}
 \input{preamble.inc}
 


### PR DESCRIPTION
I'm working on generating checklists from code. To achieve this, it would be easier to have the preamble.inc file without the '\documentclass' command.